### PR TITLE
AutoScrollDelay not work properly at the beginning

### DIFF
--- a/JCyclePictureView/JCyclePictureView.swift
+++ b/JCyclePictureView/JCyclePictureView.swift
@@ -80,7 +80,12 @@ public class JCyclePictureView: UIView {
     open var didTapAtIndexHandle: (( _: Int ) -> Void)?
     
     /// default is 2.0f, 如果小于0.5不自动播放
-    open var autoScrollDelay: TimeInterval = 2
+    open var autoScrollDelay: TimeInterval = 2 {
+        didSet {
+            stopTimer()
+            startTimer()
+        }
+    }
     
     /// 滚动方向
     open var direction: JCyclePictureViewRollingDirection = .left {

--- a/JCyclePictureViewDemo.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/JCyclePictureViewDemo.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
Reset the timer when autoScrollDelay is changed, or it will not work properly at the beginning.